### PR TITLE
Исправление ошибок

### DIFF
--- a/docs/1-foreword.en.md
+++ b/docs/1-foreword.en.md
@@ -77,7 +77,7 @@ was called Refal-5λ.
    Collected papers of functional programming language Refal, vol I
    // edited by A. P. Nemytykh. — Pereslavl-Zalessky:
    Publisher «Sbornik», 2014, 194 p. — ISBN 978-5-9905410-1-6 — page 120.
-   Available in Internet: <http://refal.botik.ru/library/refal2014_issue-I.pdf>
+   Available on the Internet: <http://refal.botik.ru/library/refal2014_issue-I.pdf>
    (in Russian)
 
 > _Translation to English of this paper is prepared by_

--- a/docs/2-intro.en.md
+++ b/docs/2-intro.en.md
@@ -17,7 +17,7 @@ all, the usage of special data structure – object expression. The most FL use
 single linked lists – the sequences of elements, in which only left side is
 accessed for direct elaboration. In other words, it is possible to make only
 such operations as looking on the first element, cutting off the first element,
-making the new list by adding an element in the beginning of the starting list.
+making the new list by adding an element at the beginning of the starting list.
 
 It is possible to derive the last element only by sequential truncation of the
 first element until the sequence won’t be empty – the last truncated element is
@@ -67,7 +67,7 @@ Refal-5λ syntax sugar is assignments and blocks, and, as it will be seen
 further, they are expressed with nested functions. These and other kinds of
 “sugar” will be told about later.
 
-Thirdly, actual implementation of Refal-5λ is not locked in contrast to a lot
+Thirdly, the actual implementation of Refal-5λ is not locked in contrast to a lot
 of other REFAL implementations. It means that  programmer is not constrained
 with some “embedded” language functions, embedded interface with C++ language
 allow the programmer to implement and use functionality in their programs on
@@ -107,9 +107,9 @@ It is possible to download and unpack `bootstrap-refal-5-lambda-***.zip` in any
 catalog from the same page
 <https://github.com/bmstu-iu9/refal-5-lambda/releases/latest>.
 
-In archive there are Refal-5λ, compiled into code on C++ and glue
+In the archive there are Refal-5λ, compiled into code on C++ and glue
 interpretive code. In order to get ready executable modules from it is
-essential to have an installed C++98 compiler on computer. It is enough to
+essential to have an installed C++98 compiler on a computer. It is enough to
 download `bootstrap.bat` file on Windows or `bootstrap.sh` on Linux or macOS –
 after distribution there will be new executable files in the bin subfolder.
 
@@ -127,7 +127,7 @@ one of them if your compiler is mentioned there). The second start is to put
 all together.
 
 Note. _On unix-like platforms (Linux, macOS)  bootstrap.sh also makes
-configured c-plus-plus.conf.sh file , but GCC C++ call is already written in
+configured c-plus-plus.conf.sh file, but GCC C++ call is already written in
 it automatically. If you want, you can change it on, for example, Clang._
 
 The content of this “half-compiled” archive is available as an archive on
@@ -151,7 +151,7 @@ It is enough to have any C++98 compiler for expanding. Distribution was tested
 on BCC 5.5, Microsoft Visual C++ of different versions, GCC C++, Clang,
 OpenWatcom.  Supported operational systems: Windows XP and newer, GNU+Linux
 (distributives not older than 5 years), macOS ( I don’t know certain versions —
-thy were tested not by me). Supported processors architectures are x386 and
+they were not tested by me). Supported processors architectures are x386 and
 amd64 (work on big endian machines is not supported in current version).
 
 **It is important!** Source codes from GitHub must be downloaded only by
@@ -167,7 +167,7 @@ sources. Probably, it will be corrected in the next versions.
 
 There are configuration files in distributive, which imply syntax highlighting
 for different text editors. If you installed REFAL on Windows, using
-automatic setup («setup.exe»), folder with configuration files is accessed
+automatic setup («setup.exe»), a folder with configuration files are accessed
 through the Start menu: “Refal-5 lambda” → “Plugins for text editors”. In all
 other cases (half-compiled archive, cloned repositories) files of texts
 editors configuration are available in `editors` subfolder.
@@ -179,7 +179,7 @@ colouring of expanded Simple Refal syntax is supported, and, probably, only for
 non-actual version.
 
 For Simple Refal there is a plugin for IDEA, that provides colouring of syntax
-errors and autocompletion, it is available on link:
+errors and autocompletion, it is available at the following link:
 
 <https://github.com/bmstu-iu9/simple-refal-plugin>
 
@@ -190,13 +190,13 @@ on the link <http://www.refal.net/~belous/refscite.htm>.
 
 ### Simple program compilation
 
-Open your favorite text editor and write the following text in it:
+Open your favourite text editor and write the following text in it:
 
     $ENTRY Go {
       = <Prout 'Hello, World!'>;
     }
 
-and save it with name `hello.ref`. After that open command line in the folder
+and save it with the name `hello.ref`. After that open command line in the folder
 with this file and write the following command:
 
     srefc hello.ref

--- a/docs/2-intro.en.md
+++ b/docs/2-intro.en.md
@@ -190,7 +190,7 @@ on the link <http://www.refal.net/~belous/refscite.htm>.
 
 ### Simple program compilation
 
-Open your favourite text editor and write the following text in it:
+Open your favorite text editor and write the following text in it:
 
     $ENTRY Go {
       = <Prout 'Hello, World!'>;

--- a/docs/3-basics.en-alt.md
+++ b/docs/3-basics.en-alt.md
@@ -22,7 +22,7 @@ Variables are written as variable type (`s`, `t`, `e`), after which goes the
 sign `.` (“dot”) and variable name-set of letters and numbers. The variable
 name often called a variable index.
 
-If variable is found in the expression not once, it is named as iterated
+If a variable is found in the expression not once, it is named as iterated
 variable and all her instances must have the same value.
 
 Let’s examine some expressions with variables:
@@ -112,7 +112,7 @@ part of the line is also a palindrome. Any other line can’t be a palindrome.
 
 The definition of functions on FL can often be read as mathematical definitions.
 
-**Example 8.** We right an add option for two binary integers of undefined
+**Example 8.** We write an add option for two binary integers of undefined
 length. Functions on Refal commit one argument, but here we want to pass two of
 them. In the first variant off add option we avoided this complexity by
 expressing function into two symbols. Now we should pass two expressions of
@@ -143,7 +143,7 @@ argument.
 
 Let’s summarize:
 
-* In the left and right parts of sentence can be variables – expressions
+* In the left and right parts of the sentence can be variables – expressions
   fragments which can be changed on undefined values in accordance with their
   type.
 * S-variables can be changed on any symbol.
@@ -152,7 +152,7 @@ Let’s summarize:
 * That function sentence is conducted, for the left part of which it is
   possible to fund such value substitution, which thunks the left part into
   function argument.
-* The same substitution is made into the right part of expression.
+* The same substitution is made into the right part of the expression.
 
 > *Translation to English of this hunk of paper is prepared by*
 > **Yarullina Diana <190471@list.ru>** _at 2018-01-17_
@@ -172,7 +172,7 @@ can work with text document like with file: transport it from one folder to
 another, copy, delete, not thinking about whether there are text, tables,
 pictures etc. in it. On defined hierarchy level it does not matter.
 
-In order to work with expression as with one object in Refal, it is put in
+In order to work with an expression as with one object in Refal, it is put in
 brackets, which are called _structure brackets._ Such object is called _bracket
 term,_ it can be a part of another expression, which can also be in brackets.
 In this way hierarchically nested data are built. Symbols, which we examined
@@ -180,9 +180,9 @@ previously, are also terms.  So, the expression on Refal consists of terms,
 each of which can be either a symbol or a brackets term, which has another
 Rrefal expression in it.
 
-As distinct to round, _structure_ brackets, angle brackets of function call in
+As distinct to round, _structure_ brackets, angle brackets of a function call in
 the right parts of sentences are called _evaluation brackets,_ _activation
-brackets_ and _function call brackets_ (all this phrases are synonyms).
+brackets_ and _function call brackets_ (all these phrases are synonyms).
 
 **Example 8.** Expression
 
@@ -200,15 +200,14 @@ part of the sentence circle and angle brackets mustn’t overlap on each other.
 Let’s make our new knowledge about variables more concrete.
 
 * E-variables can commit indoubt sequence _of terms,_ so the value of
-  e-variable can be only expression with the right brackets structure.
+  e-variable can only be an expression with the right brackets structure.
 * The value of _t-variables_ (written as `t.varname`) can be any single term –
   not only symbol, but also an expression in brackets.
 
 **Example 9.** Let’s make Pushkin’s genealogy as an expression on Refal. Each
-person of genealogy will be imaged as brackets term, which contains the
-person’s name and two terms: mother and father. And if the foregoer is known,
-it is imagined as the same person, if there is not any, then on their place
-will be sign `'?'`. So, each person can be matched with the pattern
+person of genealogy will be mapped to the brackets term, which contains the
+person’s name and two terms: mother and father. And if the ancestor is known,
+it is displayed the same way, otherwise, sign `'?'` will be used. So, each person can be matched with the pattern
 
     (e.Name t.Father t.Mother)
 
@@ -407,8 +406,7 @@ Now functions `IsEqual` and  `BinAdd` can be written the following way:
 > This section has alternative translations [one](3-basics.en.md), **two**.
 
 Earlier we said that functions in the right part of the sentence after
-substitution of variables are somehow evaluated. Now it’s time to specify how
-exactly, because without this it is impossible to write efficient programs and
+substitution of variables are somehow evaluated. Now it’s time to specify that precisely because without this it is impossible to write efficient programs and
 to debug programs in Refal-5λ.
 
 It is said that the program on Refal is performed by the _abstract
@@ -436,7 +434,7 @@ following sequence of actions:
    the machine selects the first function clause.
 4. If it is possible to select such values of the variables in the left part of
    the current sentence, that it will appeal to the argument of the function,
-   step 5 will be implemented. Otherwise the following sentence will be chosen
+   step 5 will be implemented. Otherwise, the following sentence will be chosen
    and step 4 will be repeated. If there are no more sentences, the Refal
    machine will stop with an error “recognition impossible“.
 5. The retrieved values of variables are substituted to the right part of the
@@ -464,7 +462,7 @@ Notes.
    least one sentence. Refal-5λ supports – the call of such a function leads to
    an error of impossible recognition.
 2. Current implementation at the time of creation of the program cannot check,
-   if the function `GO` or `Go` is written in the program of not. In this case,
+   if the function `GO` or `Go` is written in the program or not. In this case,
    you will create a program that by running displays an error message and
    terminates.  Perhaps this will be fixed in the next version.
 
@@ -664,7 +662,7 @@ will develop quite differently:
 Here, unencumbered calls `F` are accumulated, and they accumulate until the
 function `Rec2` ceases to call itself recursively.
 
-Similarly it turns out with nested calls of functions. Recursion in the
+Similarly, it turns out with nested calls of functions. Recursion in the
 function `Rec3` is tail:
 
     Rec3 {
@@ -708,7 +706,7 @@ Recursion in the function of `Rec4` is not tail:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     f-res
 
-Text above doesn’t meat that the tail recursion is always good, and the not
+Text above doesn’t mean that the tail recursion is always good, and the not
 tail recursion is always bad. It is just important to understand that in the
 first case the process is cyclic, the view field at each iteration returns
 to a similar state, and in the second case it grows.

--- a/docs/3-basics.en-alt.md
+++ b/docs/3-basics.en-alt.md
@@ -207,7 +207,7 @@ Let’s make our new knowledge about variables more concrete.
 **Example 9.** Let’s make Pushkin’s genealogy as an expression on Refal. Each
 person of genealogy will be mapped to the brackets term, which contains the
 person’s name and two terms: mother and father. And if the ancestor is known,
-it is displayed the same way, otherwise, sign `'?'` will be used. So, each 
+it is displayed the same way, otherwise, sign `'?'` will be used. So, each
 person can be matched with the pattern
 
     (e.Name t.Father t.Mother)
@@ -407,7 +407,7 @@ Now functions `IsEqual` and  `BinAdd` can be written the following way:
 > This section has alternative translations [one](3-basics.en.md), **two**.
 
 Earlier we said that functions in the right part of the sentence after
-substitution of variables are somehow evaluated. Now it’s time to specify that 
+substitution of variables are somehow evaluated. Now it’s time to specify that
 precisely because without this it is impossible to write efficient programs and
 to debug programs in Refal-5λ.
 

--- a/docs/3-basics.en-alt.md
+++ b/docs/3-basics.en-alt.md
@@ -207,7 +207,8 @@ Let’s make our new knowledge about variables more concrete.
 **Example 9.** Let’s make Pushkin’s genealogy as an expression on Refal. Each
 person of genealogy will be mapped to the brackets term, which contains the
 person’s name and two terms: mother and father. And if the ancestor is known,
-it is displayed the same way, otherwise, sign `'?'` will be used. So, each person can be matched with the pattern
+it is displayed the same way, otherwise, sign `'?'` will be used. So, each 
+person can be matched with the pattern
 
     (e.Name t.Father t.Mother)
 
@@ -406,7 +407,8 @@ Now functions `IsEqual` and  `BinAdd` can be written the following way:
 > This section has alternative translations [one](3-basics.en.md), **two**.
 
 Earlier we said that functions in the right part of the sentence after
-substitution of variables are somehow evaluated. Now it’s time to specify that precisely because without this it is impossible to write efficient programs and
+substitution of variables are somehow evaluated. Now it’s time to specify that 
+precisely because without this it is impossible to write efficient programs and
 to debug programs in Refal-5λ.
 
 It is said that the program on Refal is performed by the _abstract


### PR DESCRIPTION
Available on the Internet - wrong preposition + missed article
at the beginning - wrong preposition
Another important - article should not be used
Thirdly, the actual implementation - "the" missed
compilate - compile
In the archive - "the" missed
on a computer - "a" missed
the script - "the" missed
a folder - "a" missed
plugin - misspelled
favourite - misspelled
with the name - "the" missed
files are accesses - "is" does not agree with the subject
at the following link - wrong preposition + missed article
write an option - wrong word
parts of the sentence - "the" missed
of the expression - "the" missed
an expression - "an" missed
these - plural noun
specify that precisely - wrong sentence
Otherwise - missed comma
or not - misspelled
Similarly - missed comma
mean - misspelled
Coorrupted sentence in Example 9