### PR TITLE
Механизм предупреждений приближен к GCC

### DIFF
--- a/autotests/compounds.WARNING.sref
+++ b/autotests/compounds.WARNING.sref
@@ -1,3 +1,5 @@
+/* WARNING nul-in-compound */
+
 $LABEL "1 + 1", Foo, "\x20\010\n", Bar;
 
 $ENTRY Go {

--- a/autotests/init-final-entry.WARNING.ref
+++ b/autotests/init-final-entry.WARNING.ref
@@ -1,3 +1,5 @@
+* WARNING init-final-entry
+
 $ENTRY Go {
   = /* пусто */
 }

--- a/autotests/run.bat
+++ b/autotests/run.bat
@@ -343,12 +343,15 @@ goto :EOF
 
 :RUN_TEST_AUX.WARNING
 setlocal
-  echo Passing %1 (flags -Wall)...
+  for /F "tokens=3 delims= " %%f in ('
+    findstr "WARNING" %1
+  ') do set FLAG=%%f
+
   set SREF=%1
   set RASL=%~n1.rasl
-  set WARN=-Wall
-
-  ..\bin\rlc-core %WARN% --prelude=test-prelude.srefi -C %SRFLAGS% %1 2> __error.txt
+  set WARN=-W
+  echo Passing %1 (flag %WARN%%FLAG%)...
+  ..\bin\rlc-core %WARN%%FLAG% --prelude=test-prelude.srefi -C %SRFLAGS% %1 2> __error.txt
   if errorlevel 100 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit /b 1
@@ -363,8 +366,8 @@ setlocal
   echo Ok! Compilation didn't abort
   echo.
 
-  echo Passing %1 (flags -Wall -Werror)...
-  set WARN=-Wall -Werror
+  set WARN=-Werror=
+  echo Passing %1 (flag %WARN%%FLAG%)...
   ..\bin\rlc-core %WARN% --prelude=test-prelude.srefi -C %SRFLAGS% %1 2> __error.txt
   if errorlevel 100 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
@@ -379,5 +382,6 @@ setlocal
   erase __error.txt
   echo Ok! Compiler treated warnings as errors
   echo.
+
 endlocal
 goto :EOF

--- a/autotests/run.bat
+++ b/autotests/run.bat
@@ -368,7 +368,7 @@ setlocal
 
   set WARN=-Werror=
   echo Passing %1 (flag %WARN%%FLAG%)...
-  ..\bin\rlc-core %WARN% --prelude=test-prelude.srefi -C %SRFLAGS% %1 2> __error.txt
+  ..\bin\rlc-core %WARN%%FLAG% --prelude=test-prelude.srefi -C %SRFLAGS% %1 2> __error.txt
   if errorlevel 100 (
     echo COMPILER ON %1 FAILS, SEE __error.txt
     exit /b 1

--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -176,11 +176,14 @@ run_test_aux.BAD-SYNTAX() {
 }
 
 run_test_aux.WARNING() {
-  echo Passing $1 \(flags -Wall\)...
+  FLAG=$(grep 'WARNING' "$1")
+  IFS=' ' read -a array <<< "$FLAG"
+  WARN=-W"${array[2]}"
+
+  echo Passing $1 \(flag "${WARN}"\)...
   SREF=$1
   RASL=${SREF%.*}.rasl
   EXE=${SREF%.*}$(platform_exe_suffix)
-  WARN=-Wall
 
   ../bin/rlc-core ${WARN} --prelude=test-prelude.srefi -C ${SRFLAGS} ${SREF} 2>__error.txt
   if [[ $? -ge 100 ]]; then
@@ -197,8 +200,8 @@ run_test_aux.WARNING() {
   echo "Ok! Compiler didn't abort"
   echo
 
-  echo Passing $1 \(flags -Wal -Werror\)...
-  WARN='-Wall -Werror'
+  WARN="-Werror=${array[2]}"
+  echo Passing $1 \(flags "${WARN}"\)...
   ../bin/rlc-core ${WARN} --prelude=test-prelude.srefi -C ${SRFLAGS} ${SREF} 2>__error.txt
   if [[ $? -ge 100 ]]; then
     echo COMPILER ON ${SREF} FAILS, SEE __error.txt

--- a/autotests/zerocompound.WARNING.ref
+++ b/autotests/zerocompound.WARNING.ref
@@ -1,3 +1,5 @@
+* WARNING nul-in-compound
+
 $ENTRY Go {
   = <Eq ABC "ABC\x00DEF" "ABC\x00123">
 }

--- a/src/compiler/Checker.ref
+++ b/src/compiler/Checker.ref
@@ -683,13 +683,13 @@ FindInvalidForwards {
 }
 
 FindFinalInitEntry {
-  (e._ init-is-entry e._) e.Declarations
+  (e._ init-final-entry e._) e.Declarations
     = <Map
         {
           (Define t.ScrPosDefine GN-Entry e.Name)
             , <OneOf (e.Name) ('FINAL') ('INIT')> : True
             = (Define t.ScrPosDefine GN-Entry e.Name)
-              (Warning init-is-entry t.ScrPosDefine InitFinalEntry e.Name);
+              (Warning init-final-entry t.ScrPosDefine InitFinalEntry e.Name);
 
           t.OtherDeclaraion = t.OtherDeclaraion
         }

--- a/src/compiler/Config.ref
+++ b/src/compiler/Config.ref
@@ -19,7 +19,7 @@ $ENTRY Config-Create {
         )
         (Optimize /* пусто */)
         (WarningIds nul-in-compound)
-        (WarningLevel WarningsAsWarnings)
+        (WarningIdsAsErrors /* пусто */)
         (ErrorFile /* пусто */)
         (DebugMode NoMarkupContext NoDebugInfo)
         (GrammarCheck NormalRun)
@@ -394,12 +394,12 @@ Opt-Assign {
 }
 
 /**
-  <Config-GetWarningLevel t.Config>
-    == WarningLevel
+  <Config-GetWarningIdsAsErrors t.Config>
+    == WarningId*
 */
-$ENTRY Config-GetWarningLevel {
-  [Config e._ (WarningLevel s.WarningLevel) e._]
-    = s.WarningLevel;
+$ENTRY Config-GetWarningIdsAsErrors {
+  [Config e._ (WarningIdsAsErrors e.WarningIds) e._]
+    = e.WarningIds;
 }
 
 /**
@@ -416,101 +416,133 @@ $ENTRY Config-GetWarningIds {
     == Success t.Config
     == Fails BadValue-Warning e.WarningName
 
-  e.WarningName ::= 'all' | 'error' | 'screening' | 'init-final-entry' |
-                    'nul-in-compound' | 'no-screening' | 'no-init-final-entry' |
-                    'no-nul-in-compound'
+  e.WarningName ::= 'no-'? e.Error | 'no-'? e.WarningIdName | 'all'
+  e.Error ::= 'error' ('=' e.WarningName)?
+  e.WarningIdName :: = 'screening' | 'init-final-entry' | 'nul-in-compound'
+
 */
 $ENTRY Config-SetWarning {
   [Config
     e.Params-B
-    (WarningIds e.OldWarningIds)
-    (WarningLevel s.WarningLevel)
+    (WarningIds e.OldIds)
+    (WarningIdsAsErrors e.OldIdsAsErrors)
     e.Params-E
   ]
   e.WarningName
     = <ParseWarningNames e.WarningName>
     : {
-        Success WarningIds e.NewWarningIds On
+        Success WarningIds e.NewIds s.FnChange
           = Success
             [Config
               e.Params-B
-              (WarningIds <WarningIds-Add (e.OldWarningIds) e.NewWarningIds>)
-              (WarningLevel s.WarningLevel)
+              (WarningIds <s.FnChange (e.OldIds) e.NewIds>)
+              (WarningIdsAsErrors e.OldIdsAsErrors)
               e.Params-E
             ];
-        Success WarningIds e.NewWarningIds Off
+        Success WarningIdsAsErrors s.NewIdAsError s.FnChange EnableWarning
           = Success
             [Config
               e.Params-B
-              (WarningIds <WarningIds-Remove (e.OldWarningIds) e.NewWarningIds>)
-              (WarningLevel s.WarningLevel)
+              (WarningIds
+                <s.FnChange
+                  (e.OldIds)
+                  s.NewIdAsError
+                >
+              )
+              (WarningIdsAsErrors
+                <s.FnChange
+                  (e.OldIdsAsErrors)
+                  s.NewIdAsError
+                >
+              )
               e.Params-E
             ];
-        Success WarningLevel e.NewWarningLevel
+        Success WarningIdsAsErrors e.NewIdsAsErrors s.FnChange Nop
           = Success
             [Config
               e.Params-B
-              (WarningIds e.OldWarningIds)
-              (WarningLevel e.NewWarningLevel)
+              (WarningIds e.OldIds)
+              (WarningIdsAsErrors
+                <s.FnChange
+                  (e.OldIdsAsErrors)
+                  e.NewIdsAsErrors
+                >
+              )
               e.Params-E
             ];
-
         Fails e.NotParsed
           = Fails BadValue-Warning e.NotParsed;
       };
 }
 
 ParseWarningNames {
-  e.Warning, <ValidWarningId e.Warning> : True (e.WarningIds) s.Switch
-    = Success WarningIds e.WarningIds s.Switch;
-  e.Warning, <ValidWarningLevel e.Warning> : True s.WarningLevel
-    = Success WarningLevel s.WarningLevel;
+  e.Warning, <ValidWarningId e.Warning>
+    : True (e.WarningIds) s.FnChange
+    = Success WarningIds e.WarningIds s.FnChange;
+  e.Warning, <ValidWarningIdAsError e.Warning>
+    : True (e.WarningIdsAsErrors) s.FnChange s.Action
+    = Success WarningIdsAsErrors e.WarningIdsAsErrors s.FnChange s.Action;
 
   e.Unparsed = Fails e.Unparsed;
 }
 
-WarningIds-Add {
-  (e.OldIds-B s.Repeated e.OldIds-E) s.Repeated e.NewFlags
-    = <WarningIds-Add (e.OldIds-B s.Repeated e.OldIds-E) e.NewFlags>;
+ValidWarningIdAsError{
+  'no-' e.Name, <ValidWarningAsId e.Name> : True (e.Ids) s.Action
+    = True (e.Ids) &WarningIds-Remove s.Action;
+  e.Name, <ValidWarningAsId e.Name> : True (e.Ids) s.Action
+    = True (e.Ids) &WarningIds-Add s.Action;
 
-  (e.OldIds) s.NextNewFlag e.NewFlags
-    = <WarningIds-Add (e.OldIds s.NextNewFlag) e.NewFlags>;
-
-  (e.OldIds) /* пусто */ = e.OldIds;
+  e.Other = False;
 }
 
-WarningIds-Remove {
-  (e.OldIds-B s.Repeated e.OldIds-E) s.Repeated e.NewFlags
-    = <WarningIds-Remove (e.OldIds-B e.OldIds-E) e.NewFlags>;
+ValidWarningAsId {
+  'error'
+    = True <Config-AllWarningIds> Nop;
+  'error=' e.Name, <WarningForName e.Name> : True s.Id
+    = True (s.Id) EnableWarning;
 
-  (e.OldIds) s.NextNewFlag e.NewFlags
-    = <WarningIds-Remove (e.OldIds) e.NewFlags>;
-
-  (e.OldIds) /* пусто */ = e.OldIds;
+  e.Other = False;
 }
-
-
 
 ValidWarningId {
-  e.Name, <WarningForName e.Name> : True s.Id = True (s.Id) On;
-  'no-' e.Name, <WarningForName e.Name> : True s.Id = True (s.Id) Off;
-  'all' = True (screening init-is-entry nul-in-compound) On;
+  'all'
+    = True <Config-AllWarningIds> &WarningIds-Add;
+  'no-' e.Name, <WarningForName e.Name> : True s.Id
+    = True (s.Id) &WarningIds-Remove;
+  e.Name, <WarningForName e.Name> : True s.Id
+    = True (s.Id) &WarningIds-Add;
 
   e.Other = False;
 }
 
 WarningForName {
   'screening' = True screening;
-  'init-final-entry' = True init-is-entry;
+  'init-final-entry' = True init-final-entry;
   'nul-in-compound' = True nul-in-compound;
 
   e.Other = False
 }
 
-ValidWarningLevel {
-  'error' = True WarningsAsErrors;
+$ENTRY Config-AllWarningIds {
+  /* пусто */ = (screening init-final-entry nul-in-compound)
+}
 
-  e.Other = False;
+WarningIds-Add {
+  (e.OldIds-B s.Repeated e.OldIds-E) s.Repeated e.NewIds
+    = <WarningIds-Add (e.OldIds-B s.Repeated e.OldIds-E) e.NewIds>;
+  (e.OldIds) s.NextNewId e.NewIds
+    = <WarningIds-Add (e.OldIds s.NextNewId) e.NewIds>;
+
+  (e.OldIds) /* пусто */ = e.OldIds;
+}
+
+WarningIds-Remove {
+  (e.OldIds-B s.Repeated e.OldIds-E) s.Repeated e.NewIds
+    = <WarningIds-Remove (e.OldIds-B e.OldIds-E) e.NewIds>;
+  (e.OldIds) s.NextNewId e.NewIds
+    = <WarningIds-Remove (e.OldIds) e.NewIds>;
+
+  (e.OldIds) /* пусто */ = e.OldIds;
 }
 
 /**

--- a/src/compiler/Engine.ref
+++ b/src/compiler/Engine.ref
@@ -15,7 +15,7 @@ $EXTERN
   Config-GetGenMode,
   Config-GetOptTree,
   Config-GetWarningIds,
-  Config-GetWarningLevel;
+  Config-GetWarningIdsAsErrors;
 
 *$FROM Checker
 $EXTERN CheckProgram;
@@ -70,8 +70,8 @@ $ENTRY CompileFile {
     : t.ErrorList e.AST
     = <EL-Destroy
         t.ErrorList
-        <Config-GetWarningIds t.Config>
-        <Config-GetWarningLevel t.Config>
+        (<Config-GetWarningIds t.Config>)
+        (<Config-GetWarningIdsAsErrors t.Config>)
       >
     : {
         EL-NoErrors = <BackEnd t.Config (e.SrcName) (e.OutputName) e.AST>;
@@ -599,8 +599,8 @@ $ENTRY GrammarCheck {
     = <LoadAST t.Config s.Dialect e.SrcName> : t.ErrorList e.AST
     = <EL-Destroy
         t.ErrorList
-        <Config-GetWarningIds t.Config>
-        <Config-GetWarningLevel t.Config>
+        (<Config-GetWarningIds t.Config>)
+        (<Config-GetWarningIdsAsErrors t.Config>)
       >
     : {
         EL-NoErrors = Success;

--- a/src/compiler/Error.ref
+++ b/src/compiler/Error.ref
@@ -1,5 +1,6 @@
 $INCLUDE "LibraryEx";
 
+$EXTERN Config-AllWarningIds;
 
 /**
   Внутренний формат:
@@ -15,7 +16,7 @@ $INCLUDE "LibraryEx";
   s.WarningId ::=
       screening
     | nul-in-compound
-    | init-is-entry
+    | init-final-entry
 */
 $ENUM ErrorList;
 
@@ -68,7 +69,10 @@ $ENTRY EL-AddErrorAt {
 }
 
 $ENTRY EL-AddWarningAt {
-  [ErrorList (e.FileName) t.Errors (e.Warnings)] s.WarningId NoPos e.Message
+  [ErrorList (e.FileName) t.Errors (e.Warnings)]
+  s.WarningId
+  NoPos
+  e.Message
     = [ErrorList
         (e.FileName)
         t.Errors
@@ -93,14 +97,20 @@ $ENTRY EL-AddWarningAt {
         (e.FileName)
         t.Errors
         (e.Warnings
-          (s.WarningId (FileRowCol (s.Row s.Col) e.FileName) e.Message))
-      ];
+          (s.WarningId (FileRowCol (s.Row s.Col) e.FileName) e.Message)
+        )
+     ];
 
-  [ErrorList (e.FileName) t.Errors (e.Warnings)] s.WarningId t.SrcPos e.Message
+  [ErrorList (e.FileName) t.Errors (e.Warnings)]
+  s.WarningId
+  t.SrcPos
+  e.Message
     = [ErrorList
         (e.FileName)
         t.Errors
-        (e.Warnings (s.WarningId t.SrcPos e.Message))
+        (e.Warnings
+          (s.WarningId t.SrcPos e.Message)
+        )
       ];
 }
 
@@ -115,80 +125,129 @@ $ENTRY EL-Concat {
 }
 
 /*
-<EL-Destroy t.ErrorList e.EnabledWarnings s.WarningControl>
+<EL-Destroy t.ErrorList (e.EnabledWarningIds) (e.WarningIdsAsErrors)>
   == EL-NoErrors
   == EL-HasErrors
 
-e.EnabledWarnings ::= s.WarningId*
-s.WarningLevel ::=
-    WarningsAsErrors
-  | WarningsAsWarnings
+e.EnabledWarningIds ::= s.WarningId*
+e.WarningIdsAsErrors ::= s.WarningId*
 */
 $ENTRY EL-Destroy {
   [ErrorList (e.FileName) (e.Errors) (e.Warnings)]
-  e.EnabledWarnings
-  s.WarningControl
-    = <FilterEnabledWarnings (e.Warnings) e.EnabledWarnings> : e.Warnings^
+  (e.EnabledWarningIds)
+  (e.WarningIdsAsErrors)
+    = <FilterEnabledWarnings (e.Warnings) e.EnabledWarningIds> : e.Warnings^
     = <CheckHasErrors
         [ErrorList (e.FileName) (e.Errors) (e.Warnings)]
-        s.WarningControl
+        e.WarningIdsAsErrors
       >
     : s.HasErrors
     = <Map
-        (&PrintMessage 'ERROR')
+        &PrintMessageError
         <Sort e.Errors>
       >
       <Map
-        (&PrintMessage 'WARNING')
+        (&PrintMessageWarning (e.WarningIdsAsErrors))
         <Sort e.Warnings>
+      >
+      <PrintWarningsAsErrorsMessage
+        (e.FileName)
+        <CheckWarningsAsErrors (e.Warnings) e.WarningIdsAsErrors>
       >
       s.HasErrors
 }
 
 FilterEnabledWarnings {
-  (e.Warnings) e.EnabledWarnings =
+  (e.Warnings) e.EnabledWarningIds =
     <Map
-      (&IsWarningEnabled e.EnabledWarnings)
+      (&IsWarningEnabled e.EnabledWarningIds)
       e.Warnings
     >
 }
 
 IsWarningEnabled{
-  e._ s.WarningId e._ (s.WarningId e.Warning-R)
-    = (e.Warning-R);
+  e._ s.WarningId e._ (s.WarningId t.SrcPos e.Message)
+    = (s.WarningId t.SrcPos e.Message);
 
   e.WarningIds t.Skipped = /* пусто */
 }
 
 CheckHasErrors {
-  [ErrorList (e.FileName) () (e.Warnings)] WarningsAsWarnings
-    = EL-NoErrors;
-  [ErrorList (e.FileName) () ()] WarningsAsErrors
-    = EL-NoErrors;
+  [ErrorList (e.FileName) (t.Error e._) (e.Warnings)] e._
+    = EL-HasErrors;
 
-  t.ErrorList s.WarningLevel = EL-HasErrors
+  [ErrorList (e.FileName) () (e._ (s.WarningId e._) e._)]
+  e._
+  s.WarningId
+  e._
+    = EL-HasErrors;
+
+  t.ErrorList e._ = EL-NoErrors
 }
 
-PrintMessage {
-  e.MessageType (NoPos e.Message)
-    = <PrintErr '  ' e.MessageType ': ' e.Message>;
+CheckWarningsAsErrors {
+  (e._ (s.WarningId t.SrcPos e.Message) e._) e.Ids-RB s.WarningId e.Ids-RE
+  , <SetsEq
+      (e.Ids-RB s.WarningId e.Ids-RE)
+      <Config-AllWarningIds>
+    >
+  : True = All;
 
-  e.MessageType ((FileLine s.LineNumber e.FileName) e.Message)
-    = <PrintErr
-        e.FileName
-        ':' <Symb s.LineNumber>
-        ':' e.MessageType
-        ': ' e.Message
-      >;
+  (e._ (s.WarningId t.SrcPos e.Message) e._) e._ s.WarningId e._  = Some;
 
-  e.MessageType ((FileRowCol (s.Row s.Col) e.FileName) e.Message)
+  (e.Warnings) e.WarningIds = None
+}
+
+SetsEq {
+  () () = True;
+
+  (e.Set-LB s.Item e.Set-LE) (e.Set-RB s.Item e.Set-RE)
+    = <SetsEq (e.Set-LB e.Set-LE) (e.Set-RB e.Set-RE)>;
+
+  (e.Set-L) (e.Set-R) = False
+}
+
+PrintWarningsAsErrorsMessage {
+  (e.FileName) All
+    = <Prout e.FileName ': all warnings being treated as errors'>;
+  (e.FileName) Some
+    = <Prout e.FileName ': some warnings being treated as errors'>;
+
+  (e.FileName) None = /* пусто */
+}
+
+PrintMessageError {
+  (t.SrcPos e.Message)
     = <PrintErr
-        e.FileName
-        ':' <Symb s.Row>
-        ':' <Symb s.Col>
-        ':' e.MessageType
-        ': ' e.Message
+        <StrFromPos t.SrcPos>
+        'ERROR: '
+        e.Message
       >;
+}
+
+PrintMessageWarning {
+  (e._ s.WarningId e._)
+  (s.WarningId t.SrcPos e.Message)
+    = <PrintErr
+        <StrFromPos t.SrcPos>
+        'ERROR: ' e.Message ' '
+        '[-Werror=' <Explode s.WarningId> ']'
+      >;
+  (e._)
+  (s.WarningId t.SrcPos e.Message)
+    = <PrintErr
+        <StrFromPos t.SrcPos>
+        'WARNING: ' e.Message ' '
+        '[-W' <Explode s.WarningId> ']'
+      >;
+}
+
+StrFromPos {
+  NoPos = '  ';
+  (FileLine s.LineNumber e.FileName)
+    = e.FileName ':' <Symb s.LineNumber> ': ';
+  (FileRowCol (s.Row s.Col) e.FileName)
+    = e.FileName ':' <Symb s.Row> ':' <Symb s.Col> ': ';
 }
 
 $ENTRY PrintErr {

--- a/src/compiler/ParseCmdLine.ref
+++ b/src/compiler/ParseCmdLine.ref
@@ -298,10 +298,9 @@ $ENTRY ParseCommandLine {
                 (s.Pos BadValue-Warning e.BadValue) =
                    (
                      s.Pos
-                     'option -W expects \'all\', \'error\', \'screening\', '
-                     '\'init-final-entry\', \'nul-in-compound\', '
-                     '\'no-screening\', \'no-init-final-entry\', '
-                     '\'no-nul-in-compound\', but got \'' e.BadValue '\''
+                     'option -W expects \'all\', \'[no-]error[=...]\', '
+                     '\'[no-]screening\', \'[no-]init-final-entry\', '
+                     '\'[no-]nul-in-compound\', but got \'' e.BadValue '\''
                    );
 
                 (s.Pos EmptyErrorFileName)
@@ -378,10 +377,14 @@ PrintHelp {
 '-W keywords\n'
 '        Warning keywords:\n'
 '          -Wall - show all warnings\n'
-'          -Werror - treat all warnings as errors\n'
-'          -Wscreening, -Wno-screening - enable/disable screening\n'
-'          -Winit-final-entry, -Wno-init-final-entry - check/don\'t init final entry\n'
-'          -Wnul-in-compound, -Wno-nul-in-compound - check/don\'t nuls in compounds\n'
+'          -Wscreening, -Wno-... - check/don\'t screening sentences\n'
+'                                  (disabled by default)\n'
+'          -Winit-final-entry, -Wno-... - check/don\'t INIT or FINAL declared\n'
+'                                         $ENTRY (disabled by default)\n'
+'          -Wnul-in-compound, -Wno-... - check/don\'t nuls in compounds\n'
+'                                        (enabled by default)\n'
+'          -Werror[=...], -Wno-error[=...] - treat/don\'t all or only provided\n'
+'                                            warning(s) as error(s)\n'
 '-p, --prefix prefix-name\n'
 '        set prefix file name\n'
 '-r, --reference reference-name\n'


### PR DESCRIPTION
1) Конструкция `-W[no-]error[=...]`. Параметр `all` не добавлял;
2) Для предупреждений в квадратных скобках указываются их имена в виде опций командной строки;
3) Выдаются сообщения вида `***.ref: some/all warnings being treated as errors`;
4) Если был указано `-Werror=<флаг>` и обнаружено предупреждение этого типа, то при печати (как в GCC) будет выведено `ERROR`, а не `WARNING` ;
5) Конструкции вида `-Werror=<флаг>` неявно включают `-W<флаг>` (тоже как в GCC); наоборот, `-Wno-error=<флаг>` не исполняет `-Wno-<флаг>`.
6) Изменена логика для автотестов WARNING: флаг для запуска считывается из комментария в файле теста:
`* WARNING init-final-entry`
или 
`/* WARNING nul-in-compound */`