### PR TITLE
Удаление экранируемых предложений в исходниках

### DIFF
--- a/src/compiler/DisplayName.ref
+++ b/src/compiler/DisplayName.ref
@@ -28,7 +28,6 @@ $ENTRY CName {
     'var_' s.Mode <CName e.Index> '_' <Symb s.Depth>;
   e.Name SUF e.Suffix = 'gen_' <CName e.Name> '_' <CNameSuf e.Suffix>;
   e.Name = <DecorateChars e.Name>;
-  e.Name = e.Name;
 }
 
 DecorateChars {

--- a/src/compiler/GST.ref
+++ b/src/compiler/GST.ref
@@ -334,8 +334,6 @@ FoldTile {
     <FoldTile <Sub s.Weight 3> e.Items>;
 
   s.Weight e.Items = <FoldTile-EEnd s.Weight e.Items>;
-
-  s.Weight /* пусто */ = /* пусто */;
 }
 
 FoldTileW {

--- a/src/compiler/ParseCmdLine.ref
+++ b/src/compiler/ParseCmdLine.ref
@@ -60,7 +60,6 @@ $ENTRY ParseCommandLine {
           (ExtendedMode None ('extended'))
           (Log Required ('log'))
           (TreeOptCycles Required ('opt-tree-cycles'))
-          (Incorporated Required ('incorporated'))
           (Help None 'h?' ('help'))
           (Version None 'v' ('version'))
           (KeepRasls None ('keep-rasl') ('keep-rasls'))
@@ -120,9 +119,9 @@ $ENTRY ParseCommandLine {
             (t.Config e.Errors) (GrammarCheck s.Num)
               = <Update t.Config (e.Errors) &Config-SetGrammarCheck s.Num>;
 
-            (t.Config e.Errors) (Incorporated s.Num e.Name)
+            (t.Config e.Errors) (Incorporated s.Num e.LibName)
               = <Update
-                  t.Config (e.Errors) &Config-AddIncorporated s.Num e.Name
+                  t.Config (e.Errors) &Config-AddIncorporated s.Num e.LibName
                 >;
 
             (t.Config e.Errors) (MarkupContext s.Num)

--- a/src/compiler/ParseCmdLine.ref
+++ b/src/compiler/ParseCmdLine.ref
@@ -204,11 +204,6 @@ $ENTRY ParseCommandLine {
                   t.Config (e.Errors) &Config-SetTreeOptCycles s.Num e.Cycles
                 >;
 
-            (t.Config e.Errors) (Incorporated s.Num e.LibName)
-              = <Update
-                  t.Config (e.Errors) &Config-AddIncorporated s.Num e.LibName
-                >;
-
             (t.Config e.Errors) (Help s.Num) = <PrintHelp> (t.Config e.Errors);
 
             (t.Config e.Errors) (Version s.Num)


### PR DESCRIPTION
При самоприменении компилятора с флагом `-Wscreening` были обнаружены следующие экранируемые предложения:

```
DisplayName.ref:24:1: WARNING: Function `CName': sentence $4 screens sentence $5 [-Wscreening]
GST.ref:331:1: WARNING: Function `FoldTile': sentence $2 screens sentence $3 [-Wscreening]
ParseCmdLine.ref:26:1: WARNING: Function `ParseCommandLine': sentence $1\1$8 screens sentence $1\1$28 [-Wscreening]
```