### PR TITLE
Рефакторинг, учитывающий неразменные переменные

### DIFF
--- a/src/compiler/GenericMatch.ref
+++ b/src/compiler/GenericMatch.ref
@@ -31,7 +31,7 @@ FormatAssigns {
 
 $ENTRY GenericMatch {
   (e.Pattern) (e.LPattern)
-    = <Solve
+    = <Solve-Drive
         (<ExtractVariables ((e.Pattern e.LPattern) (/* пусто */))>)
         ((e.Pattern) ':' (e.LPattern))
       >
@@ -53,7 +53,7 @@ IsSVarSubset {
 }
 
 /*
-  <Solve (e.UsedVars) t.Equation>
+  <Solve-Drive (e.UsedVars) t.Equation>
     == Success t.Result* | Undefined | Failure
 
     t.Contr ::= (t.Var ':' e.Val)
@@ -62,7 +62,7 @@ IsSVarSubset {
     t.Result ::= ((t.Contr*) (t.Assign*))
 */
 
-$ENTRY Solve {
+$ENTRY Solve-Drive {
   (e.UsedVars) ((e.Expr) ':' (e.Lexpr))
     = <Solve-Aux (e.UsedVars) () ((e.Expr) ':' (e.Lexpr)) ()>
     : {
@@ -72,7 +72,7 @@ $ENTRY Solve {
     };
 }
 
-/* Преобразует формат результата функции Solve-Aux к формату Solve */
+/* Преобразует формат результата функции Solve-Aux к формату Solve-Drive */
 
 CombineResults {
   (e.Solutions) Success (e.Contrs) (e.Assigns) e.Rest

--- a/src/compiler/OptTree-Drive-Expr.ref
+++ b/src/compiler/OptTree-Drive-Expr.ref
@@ -33,34 +33,36 @@ IsPassiveCall-Aux {
 
 
 /**
-  <OptTree-Drive-Expr (e.UsedVars) t.DriveInfo e.Expr t.Mode>
+  <OptTree-Drive-Expr (e.UsedVars) (e.WholeVars) t.DriveInfo e.Expr>
     == t.OptInfo^ e.Branches (e.NewFunctions)
 
   e.Branches ::= (e.Contractions (e.DrivenExpr))*
+  e.UsedVars, e.WholeVars ::= (s.Mode e.Index)*
 */
 $ENTRY OptTree-Drive-Expr {
-  (e.UsedVars) ((e.OptFuncNames) e.OptFuncs) e.Expr t.Mode
+  (e.UsedVars) (e.WholeVars) t.OptInfo e.Expr
+     = t.OptInfo : ((e.OptFuncNames) e.OptFuncs)
      = <FindOptimizedCall (e.OptFuncNames) e.Expr>
      : {
          (e.OptFuncNames^ None) e.Expr^
            = ((e.OptFuncNames) e.OptFuncs) (/* нет сужений */ (e.Expr)) ();
 
          (e.OptFuncNames^ t.Call) e.Expr^
-           = <OptExpr-Aux (e.UsedVars) t.Mode (e.Expr) t.Call e.OptFuncs>
+           = <OptExpr-Aux (e.UsedVars) (e.WholeVars) (e.Expr) t.Call e.OptFuncs>
            : (e.OptFuncs^) (e.NewFunctions) e.Branches
            = ((e.OptFuncNames) e.OptFuncs) e.Branches (e.NewFunctions);
        };
 }
 
 OptExpr-Aux {
-  (e.UsedVars) (s.DriveMode s.IntrinsicMode) (e.Expr)
+  (e.UsedVars) (e.WholeVars) (e.Expr)
   (CallBrackets (Symbol Name e.Name) e.Args)
   t.Metatables e.OptFuncs
 
     /* Поиск информации для прогонки */
     = <FindOptInfo e.OptFuncs (e.Name)> : e.OptFuncs^ t.FunctionForDrive
     = <OptExpr-MakeSubstitutions
-        (e.UsedVars) (s.DriveMode s.IntrinsicMode) (e.Expr) (e.Args)
+        (e.UsedVars) (e.WholeVars) (e.Expr) (e.Args)
         t.FunctionForDrive t.Metatables
       >
     : t.Metatables^ e.SubstitutionPacks
@@ -571,7 +573,7 @@ Intrinsic-Last {
 
 /*
   <OptExpr-MakeSubstitutions
-    (e.UsedVars) t.Mode (e.Expr) (e.CallArgs) t.OptFunction t.Metatables
+    (e.UsedVars) (e.WholeVars) (e.Expr) (e.CallArgs) t.OptFunction t.Metatables
   >
     == t.Metatables (e.Substitutions)*
   e.Substitutions ::= e.Contractions
@@ -580,32 +582,34 @@ Intrinsic-Last {
   правой части.
 */
 OptExpr-MakeSubstitutions {
-  (e.UsedVars) (s.DriveMode Intrinsic) (e.Expr) (e.Args)
-  t.IntrinsicFunction t.Metatables
+  (e.UsedVars) (e.WholeVars) (e.Expr) (e.Args) t.IntrinsicFunction t.Metatables
     , t.IntrinsicFunction : (Intrinsic (e._) Intrinsic e.BehaviorName)
     = <IntrinsicCall t.IntrinsicFunction t.Metatables (e.Args) e.BehaviorName>;
 
-  (e.UsedVars) t.Mode (e.Expr) (e.Args) t.Function t.Metatables
+  (e.UsedVars) (e.WholeVars) (e.Expr) (e.Args) t.Function t.Metatables
     /* Активные вызовы игнорируем */
     , <IsPassiveCall e.Args> : False
 
     = t.Metatables <MakeColdSolution t.Function e.Args>;
 
-  (e.UsedVars) (s.DriveMode s.IntrinsicMode) (e.Expr) (e.Args)
+  (e.UsedVars) (e.WholeVars) (e.Expr) (e.Args)
   (s.FuncMode (e.Name) Sentences e.Body) t.Metatables
-    , <OneOf s.DriveMode Drive Inline> : True
 
-    = <DecreaseMode s.DriveMode s.FuncMode> : s.DriveMode^
+    = s.FuncMode
+    : {
+        Drive = e.WholeVars;
+        Inline = e.UsedVars;
+      }
+    : e.WholeVars^
 
     = t.Metatables
       <DoOptExpr-MakeSubstitutions
-        s.DriveMode (e.UsedVars) (e.Args)
+        (e.UsedVars) (e.WholeVars) (e.Args)
         (/* substitutions */)
         (Function (e.Name) Sentences e.Body)
       >;
 
-  (e.UsedVars) t.Mode (e.Expr) (e.Args)
-  t.Function t.Metatables
+  (e.UsedVars) (e.WholeVars) (e.Expr) (e.Args) t.Function t.Metatables
     = t.Metatables <MakeColdSolution t.Function e.Args>;
 }
 
@@ -624,13 +628,8 @@ MakeColdSolution {
       );
 }
 
-DecreaseMode {
-  Inline s.Mode = Inline;
-  Drive s.Mode = s.Mode;
-}
-
 DoOptExpr-MakeSubstitutions {
-  s.Mode (e.SentenceVars) (e.Args) (e.Substitutions)
+  (e.SentenceVars) (e.WholeVars) (e.Args) (e.Substitutions)
   (Function (e.Name) Sentences ((e.LS) (e.RS)) e.Rest)
     = <Cleanup-Step-Drop e.RS> : e.RS^
     = <Solve-Drive (e.SentenceVars) ((e.Args) ':' (e.LS))>
@@ -646,8 +645,8 @@ DoOptExpr-MakeSubstitutions {
         /*
           «Грязное» решение допускаем только в случае прогонки.
         */
-        Success e.M
-          , s.Mode : Drive
+        Success e.Solutions
+          , <SafeContractions e.Solutions (e.WholeVars)> : True
           = <Map
               {
                 ((e.Contrs) (e.Assigns))
@@ -655,11 +654,12 @@ DoOptExpr-MakeSubstitutions {
                   = e.Contrs (<eDRIVEN> ':' e.CallReplacer) : e.Contrs^
                   = (e.Contrs (/* нет новых функций */));
               }
-              e.M
+              e.Solutions
             >
-          : e.NewSubsts
+          : e.NewSubstitutions
+          = e.Substitutions e.NewSubstitutions : e.Substitutions^
           = <DoOptExpr-MakeSubstitutions
-              s.Mode (e.SentenceVars) (e.Args) (e.Substitutions e.NewSubsts)
+              (e.SentenceVars) (e.WholeVars) (e.Args) (e.Substitutions)
               (Function (<RemainderFuncIncName e.Name>) Sentences e.Rest)
             >;
 
@@ -669,7 +669,7 @@ DoOptExpr-MakeSubstitutions {
         */
         Failure
           = <DoOptExpr-MakeSubstitutions
-              s.Mode (e.SentenceVars) (e.Args) (e.Substitutions)
+              (e.SentenceVars) (e.WholeVars) (e.Args) (e.Substitutions)
               (Function (<RemainderFuncIncName e.Name>) Sentences e.Rest)
             >;
 
@@ -685,7 +685,7 @@ DoOptExpr-MakeSubstitutions {
             >;
       };
 
-  s.Mode (e.SentenceVars) (e.Args) (e.Substitutions) t.RestFunction
+  (e.SentenceVars) (e.WholeVars) (e.Args) (e.Substitutions) t.RestFunction
     = e.Substitutions <MakeColdSolution t.RestFunction e.Args>;
 }
 
@@ -698,6 +698,16 @@ Cleanup-Step-Drop {
   (CallBrackets (Symbol Name '__Step-Drop') /* пусто */) e.RS = e.RS;
 
   e.RS = e.RS;
+}
+
+SafeContractions {
+  e.Solutions-B
+  ((e.Contrs-B ((Var s.Mode e.Index) ':' e._) e.Contrs-E) (e.Assigns))
+  e.Solutions-E
+  (e.WholeVars-B (s.Mode e.Index) e.WholeVars-E)
+    = False;
+
+  e.Solutions (e.WholeVars) = False;
 }
 
 DropLeft {

--- a/src/compiler/OptTree-Drive-Expr.ref
+++ b/src/compiler/OptTree-Drive-Expr.ref
@@ -5,7 +5,7 @@ $INCLUDE "LibraryEx";
 $EXTERN HashName;
 
 *$FROM GenericMatch
-$EXTERN Solve;
+$EXTERN Solve-Drive;
 
 
 IsPassiveCall {
@@ -633,7 +633,7 @@ DoOptExpr-MakeSubstitutions {
   s.Mode (e.SentenceVars) (e.Args) (e.Substitutions)
   (Function (e.Name) Sentences ((e.LS) (e.RS)) e.Rest)
     = <Cleanup-Step-Drop e.RS> : e.RS^
-    = <Solve (e.SentenceVars) ((e.Args) ':' (e.LS))>
+    = <Solve-Drive (e.SentenceVars) ((e.Args) ':' (e.LS))>
     : {
         /*
           В случае решения без сужений просто применяем замены.

--- a/src/compiler/OptTree-Drive.ref
+++ b/src/compiler/OptTree-Drive.ref
@@ -95,6 +95,22 @@ UpdateDriveInfo {
       >
     : /* пусто */
 
+    = s.OptDrive
+    : {
+        NoOpt = /* пусто */;
+        OptInline = <Map { (Drive e.Name) = (Inline e.Name) } e.Drives>;
+        OptDrive = e.Drives;
+      }
+    : e.Drives^
+
+    = s.OptDrive
+    : {
+        NoOpt = /* пусто */;
+        OptInline = e.Inlines;
+        OptDrive = e.Inlines;
+      }
+    : e.Inlines^
+
     = <ExtractBaseNames e.Drives e.Inlines e.Metatables> : e.ExtractedNames
     = <ExtractExtractableFunctions (e.ExtractedNames) e.AST>
     : (e.Extracted) e.AST^
@@ -113,6 +129,13 @@ UpdateDriveInfo {
     = e.Drives e.Inlines e.Metatables : e.OptNames
 
     = <FormatOptFunctions (e.OptNames) e.Extracted> : e.OptFunctions
+
+    = s.OptIntrinsic
+    : {
+        NoOpt = /* пусто */;
+        OptIntrinsic = e.Intrinsics;
+      }
+    : e.Intrinsics^
 
     = <Map
         {
@@ -292,29 +315,17 @@ HashSet-AsChain {
 
 
 /**
-  <OptTree-Drive (s.OptDrive s.OptIntrinsic) e.AST> == e.AST^
+  <OptTree-Drive e.AST> == e.AST^
 */
 $ENTRY OptTree-Drive {
-  (NoOpt NoOpt) e.AST = e.AST;
-
-  (s.OptDrive s.OptIntrinsic) e.AST-B (DriveInfo e.DriveInfo) e.AST-E
-    = <DriveInlineOptimizerTick
-        (e.DriveInfo) e.AST-B e.AST-E s.OptDrive s.OptIntrinsic
-      >
-}
-
-OptSwitch {
-  OptDrive = Drive;
-  OptInline = Inline;
-  OptIntrinsic = Intrinsic;
-  NoOpt = None
+  e.AST-B (DriveInfo e.DriveInfo) e.AST-E
+    = <DriveInlineOptimizerTick (e.DriveInfo) e.AST-B e.AST-E>
 }
 
 /* Осуществляет прогонку или оптимизацию в зависимости от ключа */
 
 DriveInlineOptimizerTick {
-  ((e.OptNames) e.OptInfo) e.AST s.OptDrive s.OptIntrinsic
-    = (<OptSwitch s.OptDrive> <OptSwitch s.OptIntrinsic>) : t.Mode
+  ((e.OptNames) e.OptInfo) e.AST
     = ((e.OptNames) <WithMetatables e.OptInfo>) : t.OptInfo
     = <MapAccum
         {
@@ -322,7 +333,6 @@ DriveInlineOptimizerTick {
             = <OptFunction
                 (Function s.ScopeClass (e.Name) Sentences e.Sentences)
                 t.OptInfo
-                t.Mode
               >;
 
           t.OptInfo^ t.Other = t.OptInfo t.Other
@@ -405,7 +415,7 @@ IsLexpr-Aux {
 
 /*
   Осуществляет попытку прогонки или встраивания в функции
-  <OptFunction t.Function t.DriveInfo s.Mode>
+  <OptFunction t.Function t.DriveInfo>
     == t.DriveInfo t.OptimizedFunction t.Function*
 
   Возвращает модифицированную функцию
@@ -413,12 +423,11 @@ IsLexpr-Aux {
 */
 
 OptFunction {
-  (Function s.ScopeClass (e.Name) Sentences e.Sentences)
-  t.OptInfo t.Mode
+  (Function s.ScopeClass (e.Name) Sentences e.Sentences) t.OptInfo
     = <Reduce
         {
           (t.OptInfo^ (e.SntAcc) (e.FunAcc)) t.Sentence
-            = <OptSentence t.Sentence t.OptInfo t.Mode>
+            = <OptSentence t.Sentence t.OptInfo>
             : t.OptInfo^ (e.NewFunctions) e.NewSentences
             = (t.OptInfo (e.SntAcc e.NewSentences) (e.FunAcc e.NewFunctions));
         }
@@ -440,26 +449,25 @@ OptFunction {
 }
 
 /*
-   <OptSentence t.Sentence t.OptInfo s.Mode>
+   <OptSentence t.Sentence t.OptInfo>
    == t.OptInfo (t.Func?) t.Sentence*
 */
 
 OptSentence {
   /* Оптимизируем только предложения вида Pat = Res */
-  ((e.Left) (e.Right)) t.OptInfo t.Mode
-     = t.Mode : (s.DriveMode s.IntrinsicMode)
-
-    /* Если левая часть не L-выражение, допускаем только встраивание */
-    = <IsLexpr e.Left>
-    : {
-        True = t.Mode;
-        False = (Inline s.IntrinsicMode);
-      }
-    : t.Mode^
+  ((e.Left) (e.Right)) t.OptInfo
 
     = <ExtractVariables ((e.Left) (e.Right))> : e.SentenceVars
 
-     = <OptTree-Drive-Expr (e.SentenceVars) t.OptInfo e.Right t.Mode>
+    /* Если левая часть не L-выражение, сужения запрещаем */
+    = <IsLexpr e.Left>
+    : {
+        True = /* пусто */;
+        False = e.SentenceVars;
+      }
+    : e.WholeVars
+
+     = <OptTree-Drive-Expr (e.SentenceVars) (e.WholeVars) t.OptInfo e.Right>
      : t.OptInfo^ e.Branches (e.NewFunctions)
 
      = t.OptInfo (e.NewFunctions)
@@ -471,7 +479,7 @@ OptSentence {
          e.Branches
        >;
 
-  t.Sentence t.OptInfo t.Mode = t.OptInfo () t.Sentence
+  t.Sentence t.OptInfo = t.OptInfo () t.Sentence
 }
 
 WithMetatables {

--- a/src/compiler/OptTree.ref
+++ b/src/compiler/OptTree.ref
@@ -82,7 +82,7 @@ $ENTRY OptTree {
                 (pass
                   (trace 'before Drive')
                   (call &ExpandClosures)
-                  (call &OptTree-Drive t.OptDrive)))
+                  (call &OptTree-Drive)))
               (call &WarmColdFunctions DRIVE)
               (call &OptTree-Drive-CleanupColdCalls))
             (call &ExpandClosures)))


### PR DESCRIPTION
@VladisP, Вам интересен только первый коммит 7119e63f718a9b051fd133f00556921ec0e5dca2 — переименование функции `Solve` в `Solve-Drive`. Вам в рамках задачи #322 потребуется также написать функцию `Solve-Spec`, которая будет использоваться при специализации. Там, где `Solve-Spec` будет предлагать динамическое обобщение, функция `Solve-Drive` должна будет просто возвращать `Undefined`.

@Apakhov, я поменял интерфейс функции `OptTree-Drive`, чтобы он был совместим с оптимизациями #231 и #283, возможно, я ими займусь весной. Кроме того, ушло устаревающее деление режима прогонки на режим «прогонки» (когда сужение разрешены) и «встраивания» (когда они запрещены). Полностью это деление устареет при выполнении Вами задачи #340. Таким образом, второй коммит 1ef5b6c47cd997102af9e5361e6b9ea8d9a29cf3 — шаг в направлении #340.

Возможно, я ещё немного упрощу `OptTree-Drive` — вместо `t.Metatables` между функциями будет передаваться `e.DriveInfo`, поэтому пока это draft pull request. Чистовиком он будет либо если я это сделаю (сегодня-завтра), либо передумаю, т.к. имеющаяся архитектура уже неплоха.

-------------

Неразменные переменные (термин из старой статьи Турчина) — переменные, которые запрещено сужать при прогонке. В коде они обозначены как `e.WholeVars`.